### PR TITLE
Generalize user home dir

### DIFF
--- a/bin/commandlog-add
+++ b/bin/commandlog-add
@@ -26,7 +26,7 @@ use Cwd;
 use DBI;
 use Sys::Hostname;
 
-my $dbfile = "/home/brennen/cli.db";
+my $dbfile = $ENV{HOME} . "/cli.db";
 
 my $init_new = 0;
 $init_new = 1 unless -f $dbfile;


### PR DESCRIPTION
Use the `$HOME` env var rather than hard-code.

This change should be POSIX compliant and work across shells.

Currently untested, but a prerequisite for testing. 