### PR TITLE
Make command log accept -[NUM] argument

### DIFF
--- a/bin/commandlog-log
+++ b/bin/commandlog-log
@@ -11,7 +11,7 @@ OPTIONS:
 
 EXAMPLE:
 
-    Show last 5 commands: $ $(basname "$0") -5
+    Show last 5 commands: $ $(basename "$0") -5
 HELP
 }
 

--- a/bin/commandlog-log
+++ b/bin/commandlog-log
@@ -1,3 +1,49 @@
 #!/usr/bin/env bash
 
-sqlite3 -line ~/cli.db 'SELECT * FROM commands ORDER BY datetime DESC LIMIT 3;'
+set -e
+
+usage() {
+    cat<<HELP
+$(basename "$0") [OPTIONS]
+
+OPTIONS:
+    -[NUM]       Where [NUM] is the number of commands to show
+
+EXAMPLE:
+
+    Show last 5 commands: $ $(basname "$0") -5
+HELP
+}
+
+show_log() {
+    local log_count cmd
+    log_count="$1"
+
+    cmd=$(printf \
+        'SELECT * FROM commands ORDER BY datetime DESC LIMIT %d;' \
+        "$log_count")
+
+    exec sqlite3 -line ~/cli.db "$cmd"
+}
+
+main() {
+    local log_count
+    log_count=3
+
+    while [ -n "$1" ]; do
+        case "$1" in
+            --help|-h)
+                usage
+                exit 0
+            ;;
+        -*)
+            log_count="${1:1}"
+            ;;
+        esac
+        shift
+    done
+
+    show_log "$log_count"
+}
+
+main "$@"


### PR DESCRIPTION
It seem intuitive to pass an argument of the format -[NUM] (where [NUM]
is a number) to any command where you tail logs.

This commit adds the -[NUM] functionality to commandlog-log function as
well as handles help output.

Fixes #2